### PR TITLE
Broken link in README file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ UE5 plugin providing tools for machine learning.
 This plugin documents how to use the MLAdapter plugin for machine learning
 by reimplementing the Cartpole environment.
 
-.. image:: /_static/Cartpole_big.png
+.. image:: /Docs/_static/Cartpole_big.png
 
 
 Requirements


### PR DESCRIPTION
Hi, link to Catpole_big.png seems to be broken as it refers to "/_static/Cartpole_big.png", while file is located in "/Docs/_static/Cartpole_big.png". I've adjusted the link, thanks.